### PR TITLE
4.1.2節 (1_langgraph_component.py) 初期入力のidでルーティングされるように変更

### DIFF
--- a/chapter4/1_langgraph_component.py
+++ b/chapter4/1_langgraph_component.py
@@ -12,13 +12,13 @@ builder = StateGraph(State)
 
 # ノード関数の定義
 def search_web(state: State) -> Dict[str, Any]:
-    return {"id": 123, "messages": ["WebSearch"]}
+    return {"messages": ["WebSearch"]}
 
 def summarize(state: State) -> Dict[str, Any]:
-    return {"id": 123, "messages": ["Summarizer"]}
+    return {"messages": ["Summarizer"]}
 
 def save_record(state: State) -> Dict[str, Any]:
-    return {"id": 123, "messages": ["Recorder"]}
+    return {"messages": ["Recorder"]}
 
 # ルーティング関数の定義
 def routing_function(state: State) -> Literal["Summarizer", "Recorder"]:


### PR DESCRIPTION
## 概要
いつも参考にさせていただいています。とても分かりやすい書籍で、とても勉強になっています！

4.1.2節のサンプルコード (`1_langgraph_component.py`) を試していて気になった点があったので、PRを送らせてください。

## 気になった点
現在のコードでは、`search_web`ノードで毎回`id: 123`を返しているので、`routing_function`の条件分岐が意図通りに動作してないかと感じました。
```python
def search_web(state: State) -> Dict[str, Any]:
  return {"id": 123, "messages": ["WebSearch"]}  # 常に123
```

この場合、どんな初期入力でも必ず`Summarizer`にルーティングされて、`Recorder`には到達しないかと思います。

## 変更内容
各ノード関数で`id`を返さないようにして、初期入力の`id`でルーティングされるように変更してみました。
```python
def search_web(state: State) -> Dict[str, Any]:
  return {"messages": ["WebSearch"]}  # idは保持される
```

これで、初期入力の`id`の値によってルーティングが切り替わります。

## 動作
- `id=123`: WebSearch → Summarizer
- `id=456`: WebSearch → Recorder

もし意図と違っていたらすみません。